### PR TITLE
Create entropiafusies.rs

### DIFF
--- a/entropafusies.rs
+++ b/entropafusies.rs
@@ -1,0 +1,58 @@
+##[macro_use]
+extern crate static_assertions;
+use serde::{Deserialize, Serialize};
+#[derive(Serialize, Deserialize, Debug)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+//use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+sa::const_assert!(true); ///CUIDADO OVER DIAG
+let point = Point { x: 1, y: 2 };
+
+    // Convert the Point to a JSON string.
+    let serialized = serde_json::to_string(&point).unwrap();
+
+    // Prints serialized = {"x":1,"y":2}
+    println!("serialized = {}", serialized);
+
+    // Convert the JSON string back to a Point.
+    let deserialized: Point = serde_json::from_str(&serialized).unwrap();
+
+    // Prints deserialized = Point { x: 1, y: 2 }
+    println!("deserialized = {:?}", deserialized);
+let resp = reqwest::get("https://httpbin.org/ip")
+        .await?
+        .json::<HashMap<String, String>>()
+        .await?;
+    println!("{:#?}", resp);
+    Ok(())
+
+
+/*
+TokenStream requires set get?  
+#[proc_macro_derive(MyMacro)]
+pub fn my_macro(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+    input=<? echo"Hecho test" info.php; ?>
+    // Build the output, possibly using quasi-quotation
+    let expanded = quote! {
+        // ...
+let mut a int;
+
+    };
+
+    // Hand the output tokens back to the compiler
+    TokenStream::from(expanded)
+}
+*/
+//Finaliza el main. Test prinln
+//println!("Hola Web3");
+}
+


### PR DESCRIPTION
Usando varias librerías y métodos, trato de configurar algo que no de warning o error. Trabajando en multiples definiciones, interesado en un ecosistema substrate como soporte a eth y btc, buscando implementar un interface de usuario cuyo alias cancel, acept, read terms acept cancel puedan ser vistos cómo parte de web3 y no solo así de astar, dot, evm para multiples factores de entrada: patron, pin, key, tesla dot, glass sensor, monaspectra, etherwork. Pero fundamentado en service as nft donde un boton es un nft (visto cómo un NFT) Actualmente disponemos de Firm TRANSACTION
BUSCAR UNA DERIVACION que sin connectar la billetera, otro factor de entrada más al al fusionador (entropiafusies.rs v.1.0.124). Donde las testnet y las pruebas de cesión de sessión para test de ensallo error a pescador de código malicioso. Esto no es para piratear la red main de polkadot, hay que entender que es así con la descarga que no sé bien hacer test en la testnet rococo "favorita a hora del commit" y. Un serial de errores y warnings me restan en rust, c y lo que me alcance, hasta si ayuda las ia de tesla. Buscamos dar paquetes serios en la red rococo, kusama cuando menos. ESTABLECER SOPORTE ADMINISTRATIVO SEGURIDAD